### PR TITLE
Let scraper work on MacOS

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -22,7 +22,7 @@ options = webdriver.ChromeOptions()
 
 options.add_experimental_option("excludeSwitches", ["enable-automation"])
 options.add_experimental_option('useAutomationExtension', False)
-driver = webdriver.Chrome(options=options, executable_path=r"chromedriver.exe")
+driver = webdriver.Chrome(options=options)
 
 stealth(driver,
   languages=["en-US", "en"],


### PR DESCRIPTION
If the hard-coded executable path is removed from the webdriver initialization, the script will work on MacOS.