### PR TITLE
use non-deprecated selenium selectors when finding elements

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -1,5 +1,6 @@
 from distutils.command.clean import clean
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 from selenium_stealth import stealth
 from bs4 import BeautifulSoup
 import time
@@ -51,7 +52,7 @@ class Webdriver:
 
     window1 = driver.window_handles[1]
     driver.switch_to.window(window1)
-    source = driver.find_element_by_css_selector("html").get_attribute('outerHTML')
+    source = driver.find_element(By.TAG_NAME, "html").get_attribute("outerHTML")
     append_upcoming_and_img_urls(source)
     os.makedirs(os.path.dirname('docs/index.html'), exist_ok=True)
     with open('docs/index.html', 'w', encoding='utf-8') as f:
@@ -127,7 +128,7 @@ class Webdriver:
           upcoming_urls.remove(url)
           continue
 
-        source = self.driver.find_element_by_css_selector("html").get_attribute('outerHTML')
+        source = self.driver.find_element(By.TAG_NAME, "html").get_attribute("outerHTML")
         if not check_source_validity(source):
           error_count += 1
           if error_count > 10:

--- a/secrets.py
+++ b/secrets.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 import time
 
 # TODO: Input your tesla account details
@@ -7,13 +9,12 @@ login_delay = 0
 
 def tesla_login(driver):
   driver.get("https://tesla.com/teslaaccount")
-  driver.find_element_by_css_selector("#form-input-identity").send_keys(tesla_account_email)
+  driver.find_element(By.ID, "form-input-identity").send_keys(tesla_account_email)
   time.sleep(2 + login_delay)
-  driver.find_element_by_css_selector("#form-submit-continue").click()
+  driver.find_element(By.ID, "form-submit-continue").click()
   time.sleep(2 + login_delay)
-  driver.find_element_by_css_selector("#form-input-credential").send_keys(tesla_account_password)
+  driver.find_element(By.ID, "form-input-credential").send_keys(tesla_account_password)
   time.sleep(2 + login_delay)
-  driver.find_element_by_css_selector("#form-submit-continue").click()
+  driver.find_element(By.ID, "form-submit-continue").click()
 
   return driver
-  


### PR DESCRIPTION
This should allow for using a current version of selenium; tested with 4.2.0 (the last working version with the deprecated methods)

Should fix #9